### PR TITLE
Fix frontend Dockerfile for vite

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,16 @@
 FROM node:20-alpine
 WORKDIR /app
+
+# Install dependencies based on package.json and package-lock.json
 COPY package*.json ./
 RUN npm install
+
+# Copy the rest of the application source
 COPY . .
-EXPOSE 5173
-CMD ["npm","run","dev","--","--host","0.0.0.0","--port","5173"]
+
+# Default Vite port
+ENV PORT=5173
+EXPOSE ${PORT}
+
+# Start the development server on 0.0.0.0 for Docker
+CMD ["sh", "-c", "npm run dev -- --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
## Summary
- avoid copying `node_modules` during Docker build
- update the frontend Dockerfile to set a default Vite port and run the dev server via shell

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b539cd13883249b5740779481bf71