### PR TITLE
Add background job queue with RQ

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,57 @@
-from flask import Flask
+import os
+from flask import Flask, request, jsonify
 from flask_cors import CORS
+from redis import Redis
+from rq import Queue
+from rq.job import Job
+
+from tasks import process_dwg
 
 app = Flask(__name__)
 CORS(app)
 
+# Configure Redis connection for RQ
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
+redis_conn = Redis.from_url(redis_url)
+queue = Queue(connection=redis_conn)
+
 @app.route('/api/hello')
 def hello():
     return {'message': 'Hello from backend'}
+
+
+@app.route('/api/boq', methods=['POST'])
+def create_boq():
+    """Accepts a DWG file upload and enqueues processing."""
+    uploaded_file = request.files.get('file')
+    if not uploaded_file:
+        return jsonify({'error': 'No file provided'}), 400
+
+    # Save the uploaded file to a temporary location
+    temp_dir = os.getenv('UPLOAD_DIR', '/tmp')
+    os.makedirs(temp_dir, exist_ok=True)
+    file_path = os.path.join(temp_dir, uploaded_file.filename)
+    uploaded_file.save(file_path)
+
+    # Enqueue the processing job
+    job = queue.enqueue(process_dwg, file_path)
+    return jsonify({'job_id': job.get_id()}), 202
+
+
+@app.route('/status/<job_id>')
+def job_status(job_id):
+    """Return status information for a given job."""
+    try:
+        job = Job.fetch(job_id, connection=redis_conn)
+    except Exception:
+        return jsonify({'error': 'Invalid job ID'}), 404
+
+    response = {
+        'job_id': job_id,
+        'status': job.get_status(),
+        'result': job.result
+    }
+    return jsonify(response)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,15 @@
+import json
+import time
+
+
+def process_dwg(file_path):
+    """Mock DWG parsing and return a Bill of Quantities."""
+    # Simulate time-consuming work
+    time.sleep(2)
+    # Return dummy BoQ data
+    return {
+        "file": file_path,
+        "items": [
+            {"item_code": "A001", "description": "Mock Item", "quantity": 1, "unit": "m"}
+        ]
+    }

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,0 +1,11 @@
+import os
+from redis import Redis
+from rq import Worker, Queue, Connection
+
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379/0")
+conn = Redis.from_url(redis_url)
+
+if __name__ == "__main__":
+    with Connection(conn):
+        worker = Worker([Queue()])
+        worker.work()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 flask-cors
+redis
+rq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,23 @@
 version: '3'
 services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
   backend:
     build: ./backend
     ports:
       - "8080:8080"
+    depends_on:
+      - redis
+
+  worker:
+    build: ./backend
+    command: ["python", "app/worker.py"]
+    depends_on:
+      - redis
+
   frontend:
     build: ./frontend
     ports:


### PR DESCRIPTION
## Summary
- queue DWG processing jobs using Redis and RQ
- implement `process_dwg` task and worker process
- expose `/api/boq` endpoint and job status route
- update dependencies and compose stack with Redis/worker services

## Testing
- `python -m py_compile backend/app/main.py backend/app/tasks.py backend/app/worker.py`

------
https://chatgpt.com/codex/tasks/task_e_684b5805689483249c5838adfd8f7ecf