### PR TITLE
Add multi-file upload widget

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,0 +1,8 @@
+# Dev Notes
+
+## Multi-file Upload Component
+- Added `frontend/src/Upload.jsx` implementing drag/drop or multi-select of DWG/DXF or ZIP files.
+- Each file uploads individually to `/api/boq` with Axios `onUploadProgress` reporting progress.
+- Table lists **File**, **Status**, and **Progress %** while polling `/status/<job_id>` every 2s until completion.
+- `App.jsx` imports and renders this component alongside existing BoQ UI.
+- Vite proxy configured in `vite.config.js` to forward `/api` requests to `VITE_API_URL`.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { File, Loader2, X, UploadCloud, Download, FileText } from 'lucide-react'
 import { Toaster, toast } from 'sonner';
 // Import both functions from your api service
 import { generateBOQ, downloadExcelWithCost } from './services/api.js';
+import Upload from './Upload.jsx';
 
 export default function App() {
   const [file, setFile] = useState(null);
@@ -90,6 +91,7 @@ export default function App() {
   // (The rest of the return statement with the UI is the same and correct)
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center p-4 sm:p-6">
+      <Upload />
       <div className="w-full max-w-4xl mx-auto space-y-6">
         {/* Input Section */}
         <div className="bg-white shadow-xl rounded-xl p-8">

--- a/frontend/src/Upload.jsx
+++ b/frontend/src/Upload.jsx
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+// Base API URL is injected via docker-compose or defaults to localhost
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+/**
+ * Upload component supporting multiple DWG/DXF files or a ZIP archive.
+ * Renders per-file progress and polls backend job status.
+ */
+export default function Upload() {
+  const [jobs, setJobs] = useState([]); // [{id,name,status,progress}]
+
+  const startUpload = (file) => {
+    const jobEntry = { id: null, name: file.name, status: 'uploading', progress: 0 };
+    setJobs((prev) => [...prev, jobEntry]);
+
+    const form = new FormData();
+    form.append('file', file);
+
+    axios
+      .post(`${API_BASE}/api/boq`, form, {
+        onUploadProgress: (e) => {
+          const pct = Math.round((e.loaded * 100) / e.total);
+          setJobs((prev) =>
+            prev.map((j) =>
+              j.name === file.name && j.status === 'uploading'
+                ? { ...j, progress: pct }
+                : j
+            )
+          );
+        },
+      })
+      .then((res) => {
+        const id = res.data.job_id;
+        setJobs((prev) =>
+          prev.map((j) =>
+            j.name === file.name
+              ? { ...j, id, status: 'queued', progress: 100 }
+              : j
+          )
+        );
+        pollStatus(id);
+      })
+      .catch(() => {
+        setJobs((prev) =>
+          prev.map((j) =>
+            j.name === file.name ? { ...j, status: 'failed' } : j
+          )
+        );
+      });
+  };
+
+  const uploadFiles = (files) => {
+    for (const f of files) {
+      startUpload(f);
+    }
+  };
+
+  const pollStatus = (id) => {
+    const timer = setInterval(() => {
+      axios
+        .get(`${API_BASE}/status/${id}`)
+        .then((res) => {
+          const { status } = res.data;
+          setJobs((prev) =>
+            prev.map((j) => (j.id === id ? { ...j, status } : j))
+          );
+          if (status !== 'queued' && status !== 'started') {
+            clearInterval(timer);
+          }
+        })
+        .catch(() => {
+          setJobs((prev) =>
+            prev.map((j) => (j.id === id ? { ...j, status: 'failed' } : j))
+          );
+          clearInterval(timer);
+        });
+    }, 2000);
+  };
+
+  const handleInput = (e) => {
+    const files = e.target.files;
+    if (files && files.length) uploadFiles(files);
+  };
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    uploadFiles(e.dataTransfer.files);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h2 className="text-2xl font-semibold mb-4">Upload Files</h2>
+      <label
+        htmlFor="uploader"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={onDrop}
+        className="flex flex-col items-center justify-center w-full h-40 border-2 border-dashed rounded-xl cursor-pointer hover:border-blue-500 hover:bg-blue-50 text-slate-500 gap-2 mb-6"
+      >
+        <span className="text-center">Click or drag DWG/DXF or ZIP files here</span>
+        <input
+          id="uploader"
+          type="file"
+          accept=".dwg,.dxf,.zip"
+          multiple
+          className="hidden"
+          onChange={handleInput}
+        />
+      </label>
+
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="py-1 pr-4">File</th>
+            <th className="py-1 pr-4">Status</th>
+            <th className="py-1">Progress %</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.name} className="border-t">
+              <td className="py-1 pr-4 truncate" title={job.name}>{job.name}</td>
+              <td className="py-1 pr-4">
+                <span
+                  className={{
+                    uploading: 'text-blue-600',
+                    queued: 'text-gray-600',
+                    started: 'text-blue-600',
+                    finished: 'text-green-600',
+                    failed: 'text-red-600',
+                  }[job.status]}
+                >
+                  {job.status}
+                </span>
+              </td>
+              <td className="py-1">{job.progress}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,18 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
+// Enable proxy to backend API using VITE_API_URL when provided
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_URL || 'http://localhost:8080',
+          changeOrigin: true,
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- implement Upload component with drag/drop and progress
- proxy `/api` requests via Vite dev server
- mount Upload inside existing app
- document widget usage in DEV_NOTES

## Testing
- `node node_modules/vite/bin/vite.js build`
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684d58a42e4483248908b16a5b7d8547