### PR TITLE
Fix worker Docker build

### DIFF
--- a/backend/app/Dockerfile
+++ b/backend/app/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     python3.9 \
     python3-pip \
+    autotools-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Download and install the ODA File Converter from a reliable .tar.gz archive.


### PR DESCRIPTION
## Summary
- include `autotools-dev` so the worker image can build libredwg using autotools

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501904009883249a44941b92230a9c